### PR TITLE
FATAL error from latest develop merge, when the database handler get …

### DIFF
--- a/app/src/main/java/nl/tudelft/b_b_w/model/DatabaseHandler.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/model/DatabaseHandler.java
@@ -196,6 +196,8 @@ public class DatabaseHandler extends SQLiteOpenHelper {
                 cursor.getString(6),
                 cursor.getInt(7));
 
+        block.setSeqNumberTo(cursor.getInt(1));
+
         // Close database connection
         db.close();
 
@@ -293,7 +295,7 @@ public class DatabaseHandler extends SQLiteOpenHelper {
                 cursor.getString(5),
                 cursor.getString(6),
                 cursor.getInt(7));
-
+        block.setSeqNumberTo(cursor.getInt(1));
         // Close database connection
         db.close();
 
@@ -335,7 +337,7 @@ public class DatabaseHandler extends SQLiteOpenHelper {
                 cursor.getString(5),
                 cursor.getString(6),
                 cursor.getInt(7));
-
+        block.setSeqNumberTo(cursor.getInt(1));
         // Close database connection
         db.close();
 
@@ -377,7 +379,7 @@ public class DatabaseHandler extends SQLiteOpenHelper {
                 cursor.getString(5),
                 cursor.getString(6),
                 cursor.getInt(7));
-
+        block.setSeqNumberTo(cursor.getInt(1));
         // Close database connection
         db.close();
 
@@ -420,6 +422,7 @@ public class DatabaseHandler extends SQLiteOpenHelper {
                         cursor.getString(5),
                         cursor.getString(6),
                         cursor.getInt(7));
+                block.setSeqNumberTo(cursor.getInt(1));
                 blocks.add(block);
             } while (cursor.moveToNext());
         }

--- a/app/src/test/java/nl/tudelft/b_b_w/controller/BlockControllerUnitTest.java
+++ b/app/src/test/java/nl/tudelft/b_b_w/controller/BlockControllerUnitTest.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import nl.tudelft.b_b_w.BuildConfig;
-import nl.tudelft.b_b_w.controller.BlockController;
 import nl.tudelft.b_b_w.model.Block;
 import nl.tudelft.b_b_w.model.BlockFactory;
 import nl.tudelft.b_b_w.model.TrustValues;
@@ -56,6 +55,7 @@ public class BlockControllerUnitTest {
         this.bc = new BlockController(RuntimeEnvironment.application);
         this._block = BlockFactory.getBlock(TYPE_BLOCK, owner, ownHash,
                 previousHashChain, previousHashSender, publicKey, iban, trustValue);
+        _block.setSeqNumberTo(sequenceNumber);
     }
 
     /**
@@ -79,6 +79,7 @@ public class BlockControllerUnitTest {
     public void testGetLatestBlock() throws Exception {
         final Block expected = BlockFactory.getBlock(TYPE_BLOCK, owner, ownHash,
                 previousHashChain, previousHashSender, publicKey, iban, trustValue);
+        expected.setSeqNumberTo(1);
         bc.addBlock(_block);
         assertEquals(expected, bc.getLatestBlock(owner));
     }
@@ -111,6 +112,7 @@ public class BlockControllerUnitTest {
         final String newOwner = owner+"2";
         final Block newBlock = BlockFactory.getBlock(TYPE_BLOCK, newOwner, ownHash,
                 previousHashChain, previousHashSender, publicKey, iban, trustValue);
+        newBlock.setSeqNumberTo(1);
         bc.addBlock(_block);
         bc.addBlock(newBlock);
         List<Block> list = new ArrayList<>();
@@ -120,7 +122,7 @@ public class BlockControllerUnitTest {
         List<Block> newList = bc.getBlocks(owner);
         newList.addAll(bc.getBlocks(newOwner));
 
-        assertEquals(newList, list);
+        assertEquals(list, newList);
 }
 
     /**
@@ -149,9 +151,7 @@ public class BlockControllerUnitTest {
     @Test
     public void testEmptyList() {
         bc.addBlock(_block);
-        final Block newBlock = BlockFactory.getBlock(TYPE_BLOCK, owner, ownHash,
-                previousHashChain, previousHashSender, publicKey, iban, trustValue);
-        bc.revokeBlock(newBlock);
+        bc.revokeBlock(_block);
         List<Block> list = new ArrayList<>();
         assertEquals(list, bc.getBlocks(owner));
     }

--- a/app/src/test/java/nl/tudelft/b_b_w/model/BlockUnitTest.java
+++ b/app/src/test/java/nl/tudelft/b_b_w/model/BlockUnitTest.java
@@ -27,6 +27,7 @@ public class BlockUnitTest {
     private final String publicKey = "publicKey";
     private final boolean isRevoked = false;
     private final String iban = "iban";
+    private final int trustValue = 0;
 
 
     /**
@@ -37,7 +38,7 @@ public class BlockUnitTest {
     @Before
     public void makeNewBlock() throws Exception {
         _block = BlockFactory.getBlock(blockType, owner, ownHash,
-                previousHashChain, previousHashSender, publicKey, iban);
+                previousHashChain, previousHashSender, publicKey, iban, trustValue);
     }
 
     /**
@@ -170,7 +171,7 @@ public class BlockUnitTest {
     @Test
     public void equalsTest() throws Exception {
         final Block check = BlockFactory.getBlock(blockType, owner, ownHash,
-                previousHashChain, previousHashSender, publicKey, iban);
+                previousHashChain, previousHashSender, publicKey, iban, trustValue);
         assertTrue(_block.equals(check));
     }
 
@@ -184,7 +185,7 @@ public class BlockUnitTest {
     public void equalsFalseTest() throws Exception {
         final String _owner = "NOTOWNER";
         final Block check = BlockFactory.getBlock(blockType, _owner, ownHash,
-                previousHashChain, previousHashSender, publicKey, iban);
+                previousHashChain, previousHashSender, publicKey, iban, trustValue);
         assertFalse(_block.equals(check));
     }
 
@@ -213,8 +214,8 @@ public class BlockUnitTest {
      */
     @Test
     public void testHashCode() {
-        final Block x = new Block("owner2", ownHash, previousHashChain, previousHashSender, "pub2", iban, false);
-        final Block y = new Block("owner2", ownHash, previousHashChain, previousHashSender, "pub2", iban, false);
+        final Block x = new Block("owner2", ownHash, previousHashChain, previousHashSender, "pub2", iban,trustValue, false);
+        final Block y = new Block("owner2", ownHash, previousHashChain, previousHashSender, "pub2", iban,trustValue, false);
         assertTrue(x.equals(y) && y.equals(x));
         assertTrue(x.hashCode() == y.hashCode());
     }

--- a/app/src/test/java/nl/tudelft/b_b_w/model/DatabaseHandlerUnitTest.java
+++ b/app/src/test/java/nl/tudelft/b_b_w/model/DatabaseHandlerUnitTest.java
@@ -14,10 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import nl.tudelft.b_b_w.BuildConfig;
-import nl.tudelft.b_b_w.model.Block;
-import nl.tudelft.b_b_w.model.BlockFactory;
-import nl.tudelft.b_b_w.model.DatabaseHandler;
-import nl.tudelft.b_b_w.model.TrustValues;
 
 import static junit.framework.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
@@ -44,7 +40,7 @@ public class DatabaseHandlerUnitTest {
     private final String iban = "iban";
     private final String publicKey = "publicKey";
     private Block _block;
-
+    private final int trustValue = 0;
     /**
      * setUp method
      * Does this method before every test
@@ -54,7 +50,8 @@ public class DatabaseHandlerUnitTest {
     public void setUp() {
         this.databaseHandler = new DatabaseHandler(RuntimeEnvironment.application);
        _block =  BlockFactory.getBlock(blockType, owner, ownHash,
-                previousHashChain, previousHashSender, publicKey, iban);
+                previousHashChain, previousHashSender, publicKey, iban, trustValue);
+        _block.setSeqNumberTo(sequenceNumber);
 
 }
 
@@ -74,8 +71,9 @@ public class DatabaseHandlerUnitTest {
      */
     @Test
     public void addBlock2() {
-        final Block newBlock = BlockFactory.getBlock("REVOKE", owner, ownHash,
-                previousHashChain, previousHashSender, publicKey, iban);
+        final Block newBlock = BlockFactory.getBlock("BLOCK", owner, ownHash,
+                previousHashChain, previousHashSender, publicKey, iban, trustValue);
+        newBlock.setSeqNumberTo(2);
         databaseHandler.addBlock(_block);
         databaseHandler.addBlock(newBlock);
         List<Block> list = new ArrayList<>();
@@ -132,7 +130,7 @@ public class DatabaseHandlerUnitTest {
     public void getLatestSeqNum() {
 
         final Block block2 = BlockFactory.getBlock(blockType, owner, ownHash,
-                previousHashChain, previousHashSender, publicKey, iban);
+                previousHashChain, previousHashSender, publicKey, iban, trustValue);
         databaseHandler.addBlock(_block);
         databaseHandler.addBlock(block2);
         assertEquals(2, databaseHandler.getLatestSeqNum(owner, publicKey));
@@ -146,11 +144,12 @@ public class DatabaseHandlerUnitTest {
     @Test
     public void getLatestBlock() {
         final Block block2 = BlockFactory.getBlock(blockType, "owner2", ownHash,
-                previousHashChain, previousHashSender, publicKey, iban);
+                previousHashChain, previousHashSender, publicKey, iban,trustValue);
         databaseHandler.addBlock(_block);
         databaseHandler.addBlock(block2);
         final Block expectBlock = BlockFactory.getBlock(blockType, "owner2", ownHash,
-                previousHashChain, previousHashSender, publicKey, iban);
+                previousHashChain, previousHashSender, publicKey, iban, trustValue);
+        expectBlock.setSeqNumberTo(1);
         assertEquals(expectBlock, databaseHandler.getLatestBlock("owner2"));
     }
 
@@ -161,11 +160,12 @@ public class DatabaseHandlerUnitTest {
     @Test
     public void getBlockAfter() {
         final Block block2 = BlockFactory.getBlock(blockType, owner, ownHash,
-                previousHashChain, previousHashSender, publicKey, iban);
+                previousHashChain, previousHashSender, publicKey, iban, trustValue);
         databaseHandler.addBlock(_block);
         databaseHandler.addBlock(block2);
         final Block expectBlock = BlockFactory.getBlock(blockType, owner, ownHash,
-                previousHashChain, previousHashSender, publicKey, iban);
+                previousHashChain, previousHashSender, publicKey, iban, trustValue);
+        expectBlock.setSeqNumberTo(2);
         assertEquals(expectBlock, databaseHandler.getBlockAfter(owner, sequenceNumber));
     }
 
@@ -176,7 +176,7 @@ public class DatabaseHandlerUnitTest {
     @Test
     public void getBlockBefore() {
         final Block block2 = BlockFactory.getBlock(blockType, owner, ownHash,
-                previousHashChain, previousHashSender, publicKey, iban);
+                previousHashChain, previousHashSender, publicKey, iban, trustValue);
         databaseHandler.addBlock(_block);
         databaseHandler.addBlock(block2);
         assertEquals(databaseHandler.getBlockBefore(owner, 2), _block);
@@ -190,7 +190,9 @@ public class DatabaseHandlerUnitTest {
     public void getAllBlocks() {
         final String owner2 = "owner2";
         final Block block2 = BlockFactory.getBlock(blockType, owner2, ownHash,
-                previousHashChain, previousHashSender, publicKey, iban);
+                previousHashChain, previousHashSender, publicKey, iban, trustValue);
+        block2.setSeqNumberTo(1);
+
         databaseHandler.addBlock(_block);
         databaseHandler.addBlock(block2);
         List<Block> result = new ArrayList<>();
@@ -204,8 +206,8 @@ public class DatabaseHandlerUnitTest {
      */
     @Test
     public void updateBlockTest() {
-        final Block block2 = new Block(owner, sequenceNumber, ownHash, previousHashChain,
-                previousHashSender, publicKey, iban, isRevoked);
+        final Block block2 = new Block(owner, ownHash, previousHashChain,
+                previousHashSender, publicKey, iban, trustValue, false);
         _block.setTrustValue(TrustValues.SUCCESFUL_TRANSACTION.getValue());
         databaseHandler.updateBlock(_block);
         assertNotEquals(databaseHandler.getBlock(owner, publicKey, sequenceNumber), block2);


### PR DESCRIPTION
FATAL error from latest develop merge, when the database handler get block back from database, it fails to assign the value sequence number to the new block it makes from the information from the block it got from the database. This is fixed in this commit and tests are adjusted accordingly.

Also, the TrustValue is added into all the forgotten tests.