### PR TITLE
Feature/database refactor

### DIFF
--- a/app/src/main/java/nl/tudelft/b_b_w/model/GetDatabaseHandler.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/model/GetDatabaseHandler.java
@@ -235,44 +235,7 @@ public class GetDatabaseHandler extends AbstractDatabaseHandler {
         // return block
         return block;
     }
-
-    /**
-     * Method to get the block after a specified block
-     *
-     * @param owner          the owner of the block before
-     * @param sequenceNumber the sequencenumber of the block before
-     * @return the block after the specified one
-     */
-
-    public final Block getBlockAfter(String owner, int sequenceNumber) {
-        SQLiteDatabase db = this.getReadableDatabase();
-
-        Cursor cursor = db.query(TABLE_NAME,
-                COLUMNS,
-                KEY_OWNER + " = ? AND " + KEY_SEQ_NO + " > ?",
-                new String[]{
-                        owner, String.valueOf(sequenceNumber)
-                }, null, null, null, null);
-
-        if (cursor.getCount() < 1) {
-            throw new NotFoundException();
-        }
-
-        cursor.moveToFirst();
-
-        // extract block from cursor
-        Block block = extractBlock(cursor);
-
-        // Close database connection
-        db.close();
-
-        // Close cursor
-        cursor.close();
-
-        // return block
-        return block;
-    }
-
+    
     /**
      * Check if a block already exists in the database.
      * It is not possible to add a revoked key again.
@@ -302,42 +265,6 @@ public class GetDatabaseHandler extends AbstractDatabaseHandler {
         cursor.close();
 
         return exists;
-    }
-
-    /**
-     * Method to get the block before a specified block
-     *
-     * @param owner          the owner of the block after
-     * @param sequenceNumber the sequencenumber of the block after
-     * @return the block before the specified one
-     */
-    public final Block getBlockBefore(String owner, int sequenceNumber) {
-        SQLiteDatabase db = this.getReadableDatabase();
-
-        Cursor cursor = db.query(TABLE_NAME,
-                COLUMNS,
-                KEY_OWNER + " = ? AND " + KEY_SEQ_NO + " < ?",
-                new String[]{
-                        owner, String.valueOf(sequenceNumber)
-                }, null, null, null, null);
-
-        if (cursor.getCount() < 1) {
-            throw new NotFoundException();
-        }
-
-        cursor.moveToFirst();
-
-        // Extract block from database
-        Block block = extractBlock(cursor);
-
-        // Close database connection
-        db.close();
-
-        // Close cursor
-        cursor.close();
-
-        // return block
-        return block;
     }
 
     /**

--- a/app/src/main/java/nl/tudelft/b_b_w/model/GetDatabaseHandler.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/model/GetDatabaseHandler.java
@@ -235,7 +235,7 @@ public class GetDatabaseHandler extends AbstractDatabaseHandler {
         // return block
         return block;
     }
-    
+
     /**
      * Check if a block already exists in the database.
      * It is not possible to add a revoked key again.

--- a/app/src/test/java/nl/tudelft/b_b_w/model/DatabaseHandlerUnitTest.java
+++ b/app/src/test/java/nl/tudelft/b_b_w/model/DatabaseHandlerUnitTest.java
@@ -250,61 +250,6 @@ public class DatabaseHandlerUnitTest {
     }
 
     /**
-     * getBlockAfter test
-     * Tests the block after a block
-     */
-    @Test
-    public void getBlockAfter() {
-        mutateDatabaseHandler.addBlock(_block);
-        final Block block2 = BlockFactory.getBlock(
-                TYPE_BLOCK,
-                owner,
-                getDatabaseHandler.lastSeqNumberOfChain(owner) + 1,
-                ownHash,
-                previousHashChain,
-                previousHashSender,
-                publicKey,
-                iban,
-                trustValue
-        );
-        mutateDatabaseHandler.addBlock(block2);
-        final Block expectBlock = BlockFactory.getBlock(
-                TYPE_BLOCK,
-                owner,
-                getDatabaseHandler.lastSeqNumberOfChain(owner),
-                ownHash,
-                previousHashChain,
-                previousHashSender,
-                publicKey,
-                iban,
-                trustValue
-        );
-        assertEquals(expectBlock, getDatabaseHandler.getBlockAfter(owner, sequenceNumber));
-    }
-
-    /**
-     * getBlockBefore test
-     * Tests the block before a block
-     */
-    @Test
-    public void getBlockBefore() {
-        mutateDatabaseHandler.addBlock(_block);
-        final Block block2 = BlockFactory.getBlock(
-                TYPE_BLOCK,
-                owner,
-                getDatabaseHandler.lastSeqNumberOfChain(owner) + 1,
-                ownHash,
-                previousHashChain,
-                previousHashSender,
-                publicKey,
-                iban,
-                trustValue
-        );
-        mutateDatabaseHandler.addBlock(block2);
-        assertEquals(getDatabaseHandler.getBlockBefore(owner, 2), _block);
-    }
-
-    /**
      * getAllBlocks test
      * Tests getting all blocks
      */


### PR DESCRIPTION
# Introduction
We do not use or need the getblockbefore or getblockafter method in the getdatabasehandler, so we need to remove them.

# Purpose
We do not need them.

# Future Applicability
- 

# PR Reflection
