### PR TITLE
Mini PR: Demo won't add a user twice and won't crash

### DIFF
--- a/app/src/main/java/nl/tudelft/b_b_w/model/User.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/model/User.java
@@ -50,20 +50,19 @@ public class User {
     public String generatePublicKey() {
         //TODO: Generate public key using ED25519 protocol
         //generate SHA256 hash until this protocol is implemented
-        MessageDigest md = null;
+        MessageDigest messageDigest = null;
         try {
-            md = MessageDigest.getInstance("SHA-256");
+            messageDigest = MessageDigest.getInstance("SHA-256");
         } catch (NoSuchAlgorithmException e) {
             e.printStackTrace();
         }
         String text = name  + iban;
-
         try {
-            md.update(text.getBytes("UTF-8"));
+            messageDigest.update(text.getBytes("UTF-8"));
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
         }
-        byte[] digest = md.digest();
+        byte[] digest = messageDigest.digest();
         String hash = String.format("%064x", new java.math.BigInteger(1, digest));
         return hash;
     }

--- a/app/src/main/java/nl/tudelft/b_b_w/model/User.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/model/User.java
@@ -1,5 +1,9 @@
 package nl.tudelft.b_b_w.model;
 
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
 /**
  * Class for creating a user
  */
@@ -45,7 +49,22 @@ public class User {
      */
     public String generatePublicKey() {
         //TODO: Generate public key using ED25519 protocol
-        //generate random number until this protocol is implemented
-        return String.valueOf((int)(Math.random() * 50 + 1));
+        //generate SHA256 hash until this protocol is implemented
+        MessageDigest md = null;
+        try {
+            md = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        String text = name  + iban;
+
+        try {
+            md.update(text.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+        byte[] digest = md.digest();
+        String hash = String.format("%064x", new java.math.BigInteger(1, digest));
+        return hash;
     }
 }

--- a/app/src/main/java/nl/tudelft/b_b_w/model/User.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/model/User.java
@@ -56,7 +56,7 @@ public class User {
         } catch (NoSuchAlgorithmException e) {
             e.printStackTrace();
         }
-        String text = name  + iban;
+        String text = name + iban;
         try {
             messageDigest.update(text.getBytes("UTF-8"));
         } catch (UnsupportedEncodingException e) {

--- a/app/src/main/java/nl/tudelft/b_b_w/model/User.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/model/User.java
@@ -63,7 +63,6 @@ public class User {
             e.printStackTrace();
         }
         byte[] digest = messageDigest.digest();
-        String hash = String.format("%064x", new java.math.BigInteger(1, digest));
-        return hash;
+        return String.format("%064x", new java.math.BigInteger(1, digest));
     }
 }

--- a/app/src/main/java/nl/tudelft/b_b_w/model/User.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/model/User.java
@@ -49,7 +49,7 @@ public class User {
      */
     public String generatePublicKey() {
         //TODO: Generate public key using ED25519 protocol
-        //generate SHA256 hash until this protocol is implemented
+        //Generate SHA256 hash until this protocol is implemented
         MessageDigest messageDigest = null;
         try {
             messageDigest = MessageDigest.getInstance("SHA-256");


### PR DESCRIPTION
#119

# Introduction
The user.generatePublicKey will return a SHA256 hash in the mean time instead of random number. This has many benefits:
-The demo won't crash when a user is added twice. 
-This enables the BlockExists function to work properly.


# Purpose
-Make the demo more stable

# Future Applicability


# PR Reflection
-Easy change, big fix
-All tests passes
-demo run smoothly