### PR TITLE
added trustvaluecontroller tests and changed trustvalue type to double

### DIFF
--- a/app/src/main/java/nl/tudelft/b_b_w/controller/BlockController.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/controller/BlockController.java
@@ -69,6 +69,7 @@ public class BlockController implements BlockControllerInterface {
         // Check if the block already exists
         String owner = block.getOwner().getName();
         Block latest = getDatabaseHandler.getLatestBlock(owner);
+        TrustController trustController = new TrustController();
 
         if (latest == null) {
             mutateDatabaseHandler.addBlock(block);
@@ -76,7 +77,7 @@ public class BlockController implements BlockControllerInterface {
             throw new RuntimeException("Error - Block is already revoked");
         } else {
             if (block.isRevoked()) {
-                latest = revokedTrustValue(latest);
+                latest = trustController.revokeBlock(latest);
                 mutateDatabaseHandler.updateBlock(latest);
                 mutateDatabaseHandler.addBlock(block);
             } else {
@@ -182,56 +183,6 @@ public class BlockController implements BlockControllerInterface {
             }
         }
         return res;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    @Override
-    public final Block verifyIBAN(Block block) {
-        block.setTrustValue(TrustValues.VERIFIED.getValue());
-        mutateDatabaseHandler.updateBlock(block);
-        return block;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    @Override
-    public final Block successfulTransaction(Block block) {
-        final int maxCeil = 100;
-        final double newTrust = block.getTrustValue() + TrustValues.SUCCESFUL_TRANSACTION.getValue();
-        if (newTrust > maxCeil) {
-            block.setTrustValue(maxCeil);
-        }
-        block.setTrustValue(newTrust);
-        mutateDatabaseHandler.updateBlock(block);
-        return block;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    @Override
-    public final Block failedTransaction(Block block) {
-        final int minCeil = 0;
-        final double newTrust = block.getTrustValue() + TrustValues.FAILED_TRANSACTION.getValue();
-        if (newTrust < minCeil) {
-            block.setTrustValue(minCeil);
-        }
-        block.setTrustValue(newTrust);
-        mutateDatabaseHandler.updateBlock(block);
-        return block;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    @Override
-    public final Block revokedTrustValue(Block block) {
-        block.setTrustValue(TrustValues.REVOKED.getValue());
-        mutateDatabaseHandler.updateBlock(block);
-        return block;
     }
 
     /**

--- a/app/src/main/java/nl/tudelft/b_b_w/controller/BlockController.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/controller/BlockController.java
@@ -200,7 +200,7 @@ public class BlockController implements BlockControllerInterface {
     @Override
     public final Block successfulTransaction(Block block) {
         final int maxCeil = 100;
-        final int newTrust = block.getTrustValue() + TrustValues.SUCCESFUL_TRANSACTION.getValue();
+        final double newTrust = block.getTrustValue() + TrustValues.SUCCESFUL_TRANSACTION.getValue();
         if (newTrust > maxCeil) {
             block.setTrustValue(maxCeil);
         }
@@ -215,7 +215,7 @@ public class BlockController implements BlockControllerInterface {
     @Override
     public final Block failedTransaction(Block block) {
         final int minCeil = 0;
-        final int newTrust = block.getTrustValue() + TrustValues.FAILED_TRANSACTION.getValue();
+        final double newTrust = block.getTrustValue() + TrustValues.FAILED_TRANSACTION.getValue();
         if (newTrust < minCeil) {
             block.setTrustValue(minCeil);
         }

--- a/app/src/main/java/nl/tudelft/b_b_w/controller/BlockControllerInterface.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/controller/BlockControllerInterface.java
@@ -93,42 +93,6 @@ interface BlockControllerInterface {
     List<Block> removeBlock(List<Block> list, Block block);
 
     /**
-     * verifyIBAN method
-     * updates the trust value of the block to the set trust value for a verified IBAN
-     *
-     * @param block given block to update
-     * @return block that is updated
-     */
-    Block verifyIBAN(Block block);
-
-    /**
-     * successfulTransaction method
-     * updates the trust value of the block to the set trust value for a succesful transaction
-     *
-     * @param block given block to update
-     * @return block that is updated
-     */
-    Block successfulTransaction(Block block);
-
-    /**
-     * failedTransaction method
-     * updates the trust value of the block to the set trust value for a failed transaction
-     *
-     * @param block given block to update
-     * @return block that is updated
-     */
-    Block failedTransaction(Block block);
-
-    /**
-     * revokedTrustValue method
-     * updates the trust value of the block to the set trust value for a revoked block
-     *
-     * @param block given block to update
-     * @return block that is updated
-     */
-    Block revokedTrustValue(Block block);
-
-    /**
      * Check if the database is empty.
      *
      * @return if the database is empty

--- a/app/src/main/java/nl/tudelft/b_b_w/controller/TrustController.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/controller/TrustController.java
@@ -21,8 +21,8 @@ class TrustController {
      * @return the block with the new trust value
      */
     Block succesfulTransaction(Block block) {
-        final double newValue = distributionFunction(getX(block.getTrustValue()) +
-                REGULARIZATION_TRANSACTION);
+        final double newValue = distributionFunction(getX(block.getTrustValue())
+                + REGULARIZATION_TRANSACTION);
         block.setTrustValue(newValue);
         return block;
     }
@@ -35,8 +35,8 @@ class TrustController {
      * @return the block with the new trust value
      */
     Block failedTransaction(Block block) {
-        final double newValue = checkCeiling(distributionFunction(getX(block.getTrustValue()) -
-                REGULARIZATION_TRANSACTION));
+        final double newValue = checkCeiling(distributionFunction(getX(block.getTrustValue())
+                - REGULARIZATION_TRANSACTION));
         block.setTrustValue(newValue);
         return block;
     }
@@ -49,8 +49,8 @@ class TrustController {
      * @return the block with the new trust value
      */
     Block verifiedIBAN(Block block) {
-        final double newValue = distributionFunction(getX(block.getTrustValue()) +
-                REGULARIZATION_VERIFIED_IBAN);
+        final double newValue = distributionFunction(getX(block.getTrustValue())
+                + REGULARIZATION_VERIFIED_IBAN);
         block.setTrustValue(newValue);
         return block;
     }

--- a/app/src/main/java/nl/tudelft/b_b_w/controller/TrustController.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/controller/TrustController.java
@@ -1,0 +1,94 @@
+package nl.tudelft.b_b_w.controller;
+
+import nl.tudelft.b_b_w.model.block.Block;
+
+/**
+ * Class to edit the trust value of a block
+ */
+class TrustController {
+
+    /**
+     * Regularization parameters
+     */
+    private static final int REGULARIZATION_TRANSACTION = 1;
+    private static final int REGULARIZATION_VERIFIED_IBAN = 3;
+
+    /**
+     * succesfulTransaction
+     * Calculates the new trust value given a succesful transaction
+     *
+     * @param block the given block
+     * @return the block with the new trust value
+     */
+    Block succesfulTransaction(Block block) {
+        final double newValue = distributionFunction(getX(block.getTrustValue()) +
+                REGULARIZATION_TRANSACTION);
+        block.setTrustValue(newValue);
+        return block;
+    }
+
+    /**
+     * failedTransaction
+     * Calculates the new trust value given a failed transaction
+     *
+     * @param block the given block
+     * @return the block with the new trust value
+     */
+    Block failedTransaction(Block block) {
+        final double newValue = checkCeiling(distributionFunction(getX(block.getTrustValue()) -
+                REGULARIZATION_TRANSACTION));
+        block.setTrustValue(newValue);
+        return block;
+    }
+
+    /**
+     * verifiedIBAN
+     * Calculates the new trust value given the IBAN is verfied
+     *
+     * @param block the given block
+     * @return the block with the new trust value
+     */
+    Block verifiedIBAN(Block block) {
+        final double newValue = distributionFunction(getX(block.getTrustValue()) +
+                REGULARIZATION_VERIFIED_IBAN);
+        block.setTrustValue(newValue);
+        return block;
+    }
+
+    /**
+     * distributionFunction
+     * The exponential distribution function which distributes the trust value
+     *
+     * @param x the given parameter to calculate the distribution value from
+     * @return the distribution value
+     */
+    private double distributionFunction(double x) {
+        return 100 - 100 * Math.exp(-0.05 * x);
+    }
+
+    /**
+     * getX
+     * Gets the parameter of which the distribution value belongs to
+     *
+     * @param y given distribution value
+     * @return parameter belonging to the distribution value
+     */
+    private double getX(double y) {
+        return Math.log(1- y / 100) * -20;
+    }
+
+    /**
+     * checkCeiling
+     * Checks the limit of the value and limits it to a value above 0
+     *
+     * @param value given value to check
+     * @return new value with limits checked
+     */
+    private double checkCeiling(double value) {
+        if (value < 0) {
+            return 0;
+        } else {
+            return value;
+        }
+    }
+}

--- a/app/src/main/java/nl/tudelft/b_b_w/controller/TrustController.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/controller/TrustController.java
@@ -1,5 +1,6 @@
 package nl.tudelft.b_b_w.controller;
 
+import nl.tudelft.b_b_w.model.TrustValues;
 import nl.tudelft.b_b_w.model.block.Block;
 
 /**
@@ -52,6 +53,18 @@ class TrustController {
         final double newValue = distributionFunction(getX(block.getTrustValue())
                 + REGULARIZATION_VERIFIED_IBAN);
         block.setTrustValue(newValue);
+        return block;
+    }
+
+    /**
+     * revokeBlock
+     * Sets the block value to the revoked trust value
+     *
+     * @param block given block to revoke
+     * @return block with the new trust value
+     */
+    Block revokeBlock(Block block) {
+        block.setTrustValue(TrustValues.REVOKED.getValue());
         return block;
     }
 

--- a/app/src/main/java/nl/tudelft/b_b_w/controller/TrustController.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/controller/TrustController.java
@@ -74,7 +74,7 @@ class TrustController {
      * @return parameter belonging to the distribution value
      */
     private double getX(double y) {
-        return Math.log(1- y / 100) * -20;
+        return Math.log(1 - y / 100) * -20;
     }
 
     /**

--- a/app/src/main/java/nl/tudelft/b_b_w/model/AbstractDatabaseHandler.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/model/AbstractDatabaseHandler.java
@@ -75,7 +75,7 @@ abstract class AbstractDatabaseHandler extends SQLiteOpenHelper {
                 + KEY_PREV_HASH_SENDER + " TEXT NOT NULL,"
                 + KEY_PUBLIC_KEY + " TEXT NOT NULL,"
                 + KEY_IBAN_KEY + " TEXT NOT NULL,"
-                + KEY_TRUST_VALUE + " INTEGER NOT NULL,"
+                + KEY_TRUST_VALUE + " DECIMAL(8,3) NOT NULL,"
                 + KEY_REVOKE + " BOOLEAN DEFAULT FALSE NOT NULL,"
                 + KEY_CREATED_AT + " TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,"
                 + " PRIMARY KEY (owner, publicKey, sequenceNumber)"

--- a/app/src/main/java/nl/tudelft/b_b_w/model/TrustValues.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/model/TrustValues.java
@@ -7,7 +7,7 @@ public enum TrustValues {
     /**
      * Predefined trust values
      */
-    INITIALIZED(20), REVOKED(0), VERIFIED(50), SUCCESFUL_TRANSACTION(10), FAILED_TRANSACTION(-10);
+    INITIALIZED(10), REVOKED(0), VERIFIED(20), SUCCESFUL_TRANSACTION(10), FAILED_TRANSACTION(-10);
 
     /**
      * value of the predefined trust values

--- a/app/src/main/java/nl/tudelft/b_b_w/model/TrustValues.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/model/TrustValues.java
@@ -7,7 +7,7 @@ public enum TrustValues {
     /**
      * Predefined trust values
      */
-    INITIALIZED(10), REVOKED(0), VERIFIED(20), SUCCESFUL_TRANSACTION(10), FAILED_TRANSACTION(-10);
+    INITIALIZED(10), REVOKED(0);
 
     /**
      * value of the predefined trust values

--- a/app/src/main/java/nl/tudelft/b_b_w/model/block/Block.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/model/block/Block.java
@@ -119,7 +119,7 @@ public abstract class Block {
      *
      * @return the trust value of the block
      */
-    public final int getTrustValue() {
+    public final double getTrustValue() {
         return blockData.getTrustValue();
     }
 
@@ -128,7 +128,7 @@ public abstract class Block {
      *
      * @param trustValue trust value to set
      */
-    public final void setTrustValue(int trustValue) {
+    public final void setTrustValue(double trustValue) {
         blockData.setTrustValue(trustValue);
     }
 

--- a/app/src/main/java/nl/tudelft/b_b_w/model/block/BlockData.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/model/block/BlockData.java
@@ -49,7 +49,7 @@ public class BlockData {
     /**
      * The trust value of this block
      */
-    private int trustValue;
+    private double trustValue;
 
     /**
      * Get the block type
@@ -173,7 +173,7 @@ public class BlockData {
      *
      * @return the trust value of this block
      */
-    public int getTrustValue() {
+    public double getTrustValue() {
         return trustValue;
     }
 
@@ -182,7 +182,7 @@ public class BlockData {
      *
      * @param trustValue the trust value of this block
      */
-    public void setTrustValue(int trustValue) {
+    public void setTrustValue(double trustValue) {
         this.trustValue = trustValue;
     }
 }

--- a/app/src/main/java/nl/tudelft/b_b_w/model/block/BlockFactory.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/model/block/BlockFactory.java
@@ -45,7 +45,7 @@ public final class BlockFactory {
     @Deprecated
     public static final Block getBlock(String type, String newOwner, int sequenceIndex, String hash,
                                        String previousHashChain, String previousHashSender,
-                                       String publicKey, String iban, int trustValue) throws
+                                       String publicKey, String iban, double trustValue) throws
             HashException {
         // fill in values
         BlockData data = new BlockData();

--- a/app/src/main/java/nl/tudelft/b_b_w/view/ContactAdapter.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/view/ContactAdapter.java
@@ -169,7 +169,7 @@ public class ContactAdapter extends BaseAdapter implements ListAdapter {
             ibanItemText.setText(blockController.getBlocks(ownerName).get(position).getOwner().getIban());
             ImageView pic = (ImageView) view.findViewById(R.id.trust_image);
             pic.setImageResource(
-                    getImageNo(blockController.getBlocks(ownerName).get(position).getTrustValue()));
+                    getImageNo((int) Math.ceil(blockController.getBlocks(ownerName).get(position).getTrustValue())));
             Button revokeButton = (Button) view.findViewById(R.id.revoke_btn);
             revokeButton.setOnClickListener(createDialog(position));
             return view;

--- a/app/src/main/java/nl/tudelft/b_b_w/view/ContactAdapter.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/view/ContactAdapter.java
@@ -169,7 +169,7 @@ public class ContactAdapter extends BaseAdapter implements ListAdapter {
             ibanItemText.setText(blockController.getBlocks(ownerName).get(position).getOwner().getIban());
             ImageView pic = (ImageView) view.findViewById(R.id.trust_image);
             pic.setImageResource(
-                    getImageNo((int) Math.ceil(blockController.getBlocks(ownerName).get(position).getTrustValue())));
+                    getImageNo((int) Math.round(blockController.getBlocks(ownerName).get(position).getTrustValue())));
             Button revokeButton = (Button) view.findViewById(R.id.revoke_btn);
             revokeButton.setOnClickListener(createDialog(position));
             return view;

--- a/app/src/main/java/nl/tudelft/b_b_w/view/FriendsContactAdapter.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/view/FriendsContactAdapter.java
@@ -171,7 +171,7 @@ public class FriendsContactAdapter extends BaseAdapter implements ListAdapter {
             ibanItemText.setText(blockController.getBlocks(ownerName).get(position).getOwner().getIban());
             ImageView pic = (ImageView) view.findViewById(R.id.trust_image2);
             pic.setImageResource(
-                    getImageNo(blockController.getBlocks(ownerName).get(position).getTrustValue()));
+                    getImageNo((int) Math.ceil(blockController.getBlocks(ownerName).get(position).getTrustValue())));
             Button addButton = (Button) view.findViewById(R.id.add_btn);
             addButton.setOnClickListener(createDialog(position));
             return view;

--- a/app/src/main/java/nl/tudelft/b_b_w/view/FriendsContactAdapter.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/view/FriendsContactAdapter.java
@@ -171,7 +171,7 @@ public class FriendsContactAdapter extends BaseAdapter implements ListAdapter {
             ibanItemText.setText(blockController.getBlocks(ownerName).get(position).getOwner().getIban());
             ImageView pic = (ImageView) view.findViewById(R.id.trust_image2);
             pic.setImageResource(
-                    getImageNo((int) Math.ceil(blockController.getBlocks(ownerName).get(position).getTrustValue())));
+                    getImageNo((int) Math.round(blockController.getBlocks(ownerName).get(position).getTrustValue())));
             Button addButton = (Button) view.findViewById(R.id.add_btn);
             addButton.setOnClickListener(createDialog(position));
             return view;

--- a/app/src/main/java/nl/tudelft/b_b_w/view/TransactionActivity.java
+++ b/app/src/main/java/nl/tudelft/b_b_w/view/TransactionActivity.java
@@ -77,7 +77,7 @@ public class TransactionActivity extends Activity {
                     final int amount = Integer.parseInt(amountText.getText().toString());
                     for (Block block : blockController.getBlocks(user.getName())) {
                         if (blockController.backtrack(block).getOwner().getName().equals(transactionName)) {
-                            blockController.successfulTransaction(block);
+                            //TODO update trust value of block using new api
                             Toast.makeText(TransactionActivity.this, "Send €" + amount + " to "
                                     + transactionName + "!", Toast.LENGTH_SHORT).show();
                         }

--- a/app/src/test/java/nl/tudelft/b_b_w/controller/BlockControllerUnitTest.java
+++ b/app/src/test/java/nl/tudelft/b_b_w/controller/BlockControllerUnitTest.java
@@ -144,52 +144,6 @@ public class BlockControllerUnitTest {
     }
 
     /**
-     * verifyIBAN test
-     * Tests whether verifying the IBAN updates the trust value
-     */
-    @Test
-    public final void testVerifyIBAN() {
-        Block b = blockWithOwnerAAddsKeyKb;
-        blockController.verifyIBAN(b);
-        assertEquals(TrustValues.VERIFIED.getValue(), b.getTrustValue());
-    }
-
-    /**
-     * successfulTransaction test
-     * Tests whether a successful transaction updates the trust value
-     */
-    @Test
-    public final void testSuccessfulTransaction() {
-        Block b = blockWithOwnerAAddsKeyKb;
-        blockController.successfulTransaction(b);
-        assertEquals(TrustValues.INITIALIZED.getValue() + TrustValues.SUCCESFUL_TRANSACTION.getValue(),
-                b.getTrustValue());
-    }
-
-    /**
-     * failedTransaction test
-     * Tests whether a successful transaction updates the trust value
-     */
-    @Test
-    public final void testFailedTransaction() {
-        Block b = blockWithOwnerAAddsKeyKb;
-        blockController.failedTransaction(b);
-        assertEquals(TrustValues.INITIALIZED.getValue() + TrustValues.FAILED_TRANSACTION.getValue(),
-                b.getTrustValue());
-    }
-
-    /**
-     * revokedTrustValue test
-     * Tests whether a revoked transaction updates the trust value
-     */
-    @Test
-    public final void testRevokedTrustValue() {
-        Block b = blockWithOwnerAAddsKeyKb;
-        blockController.revokedTrustValue(b);
-        assertEquals(TrustValues.REVOKED.getValue(), b.getTrustValue());
-    }
-
-    /**
      * Check that the genesis block is created
      */
     @Test

--- a/app/src/test/java/nl/tudelft/b_b_w/controller/BlockControllerUnitTest.java
+++ b/app/src/test/java/nl/tudelft/b_b_w/controller/BlockControllerUnitTest.java
@@ -13,7 +13,6 @@ import java.util.List;
 
 import nl.tudelft.b_b_w.BuildConfig;
 import nl.tudelft.b_b_w.model.HashException;
-import nl.tudelft.b_b_w.model.TrustValues;
 import nl.tudelft.b_b_w.model.User;
 import nl.tudelft.b_b_w.model.block.Block;
 import nl.tudelft.b_b_w.model.block.BlockData;

--- a/app/src/test/java/nl/tudelft/b_b_w/controller/TrustControllerUnitTest.java
+++ b/app/src/test/java/nl/tudelft/b_b_w/controller/TrustControllerUnitTest.java
@@ -1,0 +1,81 @@
+package nl.tudelft.b_b_w.controller;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import nl.tudelft.b_b_w.BuildConfig;
+import nl.tudelft.b_b_w.model.HashException;
+import nl.tudelft.b_b_w.model.User;
+import nl.tudelft.b_b_w.model.block.Block;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test class for CryptoController
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 21, manifest = "src/main/AndroidManifest.xml")
+public class TrustControllerUnitTest {
+
+    /**
+     * Class attributes
+     */
+    private static final double DELTA = 1e-15;
+    private TrustController trustController;
+    private Block block;
+
+    /**
+     * initialize method
+     * Initialized the TrustController, BlockController and a test block
+     */
+    @Before
+    public void initialize() throws HashException {
+        this.trustController = new TrustController();
+        final String name = "name";
+        final String iban = "iban";
+        final User user = new User(name, iban);
+        this.block = new BlockController(RuntimeEnvironment.application).createGenesis(user);
+    }
+
+    /**
+     * Tests whether a successful transaction updates the trust value
+     */
+    @Test
+    public void testSuccesfulTransaction() {
+        block = trustController.succesfulTransaction(block);
+        assertEquals(14.389351794935735, block.getTrustValue(), DELTA);
+    }
+
+    /**
+     * Tests whether a failed transaction updates the trust value
+     */
+    @Test
+    public void testFailedTransaction() {
+        block = trustController.failedTransaction(block);
+        assertEquals(5.38560132615784, block.getTrustValue(), DELTA);
+    }
+
+    /**
+     * Tests whether verifying the iban updates the trust value
+     */
+    @Test
+    public void testVerifiedIBAN() {
+        block = trustController.verifiedIBAN(block);
+        assertEquals(22.536282121744804, block.getTrustValue(), DELTA);
+    }
+
+    /**
+     * Tests whether the trust value does not go under the limit
+     */
+    @Test
+    public void testUnderCeiling() {
+        block.setTrustValue(0);
+        block = trustController.failedTransaction(block);
+        assertEquals(0, block.getTrustValue(), DELTA);
+    }
+
+}

--- a/app/src/test/java/nl/tudelft/b_b_w/controller/TrustControllerUnitTest.java
+++ b/app/src/test/java/nl/tudelft/b_b_w/controller/TrustControllerUnitTest.java
@@ -78,4 +78,13 @@ public class TrustControllerUnitTest {
         assertEquals(0, block.getTrustValue(), DELTA);
     }
 
+    /**
+     * Test to check whether revoking a block works
+     */
+    @Test
+    public void testRevokeBlock() {
+        block = trustController.revokeBlock(block);
+        assertEquals(0, block.getTrustValue(), DELTA);
+    }
+
 }

--- a/app/src/test/java/nl/tudelft/b_b_w/model/DatabaseHandlerUnitTest.java
+++ b/app/src/test/java/nl/tudelft/b_b_w/model/DatabaseHandlerUnitTest.java
@@ -296,7 +296,7 @@ public class DatabaseHandlerUnitTest {
                 iban,
                 trustValue
         );
-        block.setTrustValue(TrustValues.SUCCESFUL_TRANSACTION.getValue());
+        block.setTrustValue(TrustValues.REVOKED.getValue());
         mutateDatabaseHandler.updateBlock(block);
         assertNotEquals(getDatabaseHandler.getBlock(owner, publicKey, sequenceNumber), block2);
     }

--- a/app/src/test/java/nl/tudelft/b_b_w/model/GenesisBlockUnitTest.java
+++ b/app/src/test/java/nl/tudelft/b_b_w/model/GenesisBlockUnitTest.java
@@ -147,7 +147,7 @@ public class GenesisBlockUnitTest {
      */
     @Test
     public void testTrustGenesis() {
-        assertEquals(TrustValues.INITIALIZED.getValue(), genesisBlockA.getTrustValue());
+        assertEquals(TrustValues.INITIALIZED.getValue(), genesisBlockA.getTrustValue(), 1E-15);
     }
 
     /**

--- a/app/src/test/java/nl/tudelft/b_b_w/model/TrustValuesUnitTest.java
+++ b/app/src/test/java/nl/tudelft/b_b_w/model/TrustValuesUnitTest.java
@@ -13,7 +13,7 @@ public class TrustValuesUnitTest {
      */
     @Test
     public void testTrustValuesInitialized() {
-        assertEquals(20, TrustValues.INITIALIZED.getValue());
+        assertEquals(10, TrustValues.INITIALIZED.getValue());
     }
 
     /**
@@ -23,32 +23,5 @@ public class TrustValuesUnitTest {
     @Test
     public void testTrustValuesRevoke() {
         assertEquals(0, TrustValues.REVOKED.getValue());
-    }
-
-    /**
-     * testTrustValuesVerified
-     * tests whether the trust value of the verified is correct
-     */
-    @Test
-    public void testTrustValuesVerified() {
-        assertEquals(50, TrustValues.VERIFIED.getValue());
-    }
-
-    /**
-     * testTrustValuesSuccessfulTransaction
-     * tests whether the trust value of the successful transaction is correct
-     */
-    @Test
-    public void testTrustValuesSuccessfulTransaction() {
-        assertEquals(10, TrustValues.SUCCESFUL_TRANSACTION.getValue());
-    }
-
-    /**
-     * testTrustValuesFailedTransaction
-     * tests whether the trust value of the failed transaction is correct
-     */
-    @Test
-    public void testTrustValuesFailedTransaction() {
-        assertEquals(-10, TrustValues.FAILED_TRANSACTION.getValue());
     }
 }


### PR DESCRIPTION
#130 

# Introduction
The current trust value implementation is pretty simple. So it is changed to a way now that the trust value is updated in a decreasing ascending way. Next to that, the trust value type has been changed to a double. All functions, which influence the trust value have been extracted to a new controller: TrustController

# Purpose
This way, the trust value will be calculated more accurately and the trust value will reach the upper limit slower. And because the TrustController has been extracted, the code has increased in readability and maintainability.

# Future Applicability
Use the TrustController to update the trust values. The enums 'FAILED_TRANSACTION', 'SUCCESFUL_TRANSACTION' and 'VERIFIED_IBAN' have to be removed later, after the refactor

# PR Reflection
- 