### PR TITLE
excluded view folder for coverage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,8 +55,13 @@ apply plugin: "com.github.kt3k.coveralls"
 apply plugin: 'cobertura'
 
 cobertura {
+    coverageExcludes = [
+            ".*nl.tudelft.b_b_w.view.*",
+            ".*com.jjoe64.*",
+            ".*android.*"
+    ]
     coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report
-    coverageExcludes = ["${project.rootDir}/app/src/main/java/nl.tudelft.b_b_w/view"]
+    coverageReportDir = new File("$buildDir/reports/cobertura")
 }
 
 check.dependsOn 'checkstyle', 'findbugs', 'pmd'
@@ -108,3 +113,5 @@ task pmd(type: Pmd) {
         html.enabled = true
     }
 }
+
+check.finalizedBy(project.tasks.cobertura)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,7 @@ apply plugin: 'cobertura'
 
 cobertura {
     coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report
-    coverageExcludes = ['src/main/java/nl.tudelft.b_b_w/view']
+    coverageExcludes = ["${project.rootDir}/app/src/main/java/nl.tudelft.b_b_w/view"]
 }
 
 check.dependsOn 'checkstyle', 'findbugs', 'pmd'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,7 +54,10 @@ apply plugin: 'checkstyle'
 apply plugin: "com.github.kt3k.coveralls"
 apply plugin: 'cobertura'
 
-cobertura.coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report
+cobertura {
+    coverageFormats = ['html', 'xml'] // coveralls plugin depends on xml format report
+    coverageExcludes = ['src/main/java/nl.tudelft.b_b_w/view']
+}
 
 check.dependsOn 'checkstyle', 'findbugs', 'pmd'
 


### PR DESCRIPTION
#148

# Introduction
Currently, the activities are taken into the coverage of the project as well, but it has to be excluded.

# Purpose
To exclude the view package from the coverage

# Future Applicability
-

# PR Reflection
- 